### PR TITLE
Patch "No available addresses" CNI Plugin Issue

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -22,7 +22,7 @@ const (
 	// AzureCniPluginVer specifies version of Azure CNI plugin, which has been mirrored from
 	// https://github.com/Azure/azure-container-networking/releases/download/${AZURE_PLUGIN_VER}/azure-vnet-cni-linux-amd64-${AZURE_PLUGIN_VER}.tgz
 	// to https://acs-mirror.azureedge.net/cni
-	AzureCniPluginVer = "v1.0.7"
+	AzureCniPluginVer = "v1.0.12"
 	// CNIPluginVer specifies the version of CNI implementation
 	// https://github.com/containernetworking/plugins
 	CNIPluginVer = "v0.7.1"


### PR DESCRIPTION
This commit upgrades the Azure CNI Plugin to patch a bug where the
plugin fails to free IPs when a pod is cleaned up. This will fix the
issue we are seeing with clusters running out of IPs, despite having far
fewer pods running than IPs available.

Ref: PLAT-672